### PR TITLE
Support for .NET Core without DNX

### DIFF
--- a/CodeCakeBuilder/NuSpec/SimpleGitVersion.DNXCommand.nuspec
+++ b/CodeCakeBuilder/NuSpec/SimpleGitVersion.DNXCommand.nuspec
@@ -19,15 +19,17 @@
     <language>en-US</language>
     <tags>Git, Tag, Versioning, NuGet, SemVer, CSemVer, DNX</tags>
     <developmentDependency>true</developmentDependency>
-    <dependencies>
-      <dependency id="SimpleGitVersion.Core" version="$version$" />
-    </dependencies>
     <releaseNotes>https://github.com/SimpleGitVersion/SGV-Net/releases</releaseNotes>
   </metadata>
   <files>
-    <file src="SimpleGitVersion.DNXCommands\bin\{{configuration}}\SimpleGitVersion.DNXCommands.exe" target="lib/net45/SimpleGitVersion.DNXCommands.exe" />
-    <file src="SimpleGitVersion.DNXCommands\bin\{{configuration}}\SimpleGitVersion.DNXCommands.pdb" target="lib/net45/SimpleGitVersion.DNXCommands.pdb" />
-    
+    <file src="SimpleGitVersion.DNXCommands\bin\{{configuration}}\dotnet-sgv.exe" target="lib/net45/dotnet-sgv.exe" />
+    <file src="SimpleGitVersion.DNXCommands\bin\{{configuration}}\dotnet-sgv.pdb" target="lib/net45/dotnet-sgv.pdb" />
+    <file src="SimpleGitVersion.Core\bin\{{configuration}}\ILMerged\SimpleGitVersion.Core.dll" target="lib\net45" />
+    <file src="SimpleGitVersion.Core\bin\{{configuration}}\ILMerged\SimpleGitVersion.Core.pdb" target="lib\net45" />
+    <file src="SimpleGitVersion.Core\bin\{{configuration}}\SimpleGitVersion.Core.xml" target="lib\net45" />
+    <file src="SimpleGitVersion.Core\bin\{{configuration}}\NativeBinaries\amd64\*.dll" target="NativeBinaries\amd64" />
+    <file src="SimpleGitVersion.Core\bin\{{configuration}}\NativeBinaries\x86\*.dll" target="NativeBinaries\x86" />
+
     <file src="CodeCakeBuilder\Releases\SimpleGitVersion.DNXCommands\app\*" target="app/" />
   </files>
 

--- a/SimpleGitVersion.DNXCommands/SimpleGitVersion.DNXCommands.csproj
+++ b/SimpleGitVersion.DNXCommands/SimpleGitVersion.DNXCommands.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleGitVersion.DNXCommands</RootNamespace>
-    <AssemblyName>SimpleGitVersion.DNXCommands</AssemblyName>
+    <AssemblyName>dotnet-sgv</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Hi, I'm sharing my findings on making this project work with the current .NET Core tooling. Given that the tooling is going to change in 6 months, it may not be worth integrating this.

The below code changes will create a nuget that will work with dotnet without requiring DNX to be installed. In the destination project, the following would need to be added to the `project.json`:

```
"tools": {
    "SimpleGitVersion.DNXCommands": {
      "version": "0.19.1",
      "imports": "net45"
    }
  },
  "scripts": {
    "precompile": "dotnet sgv update"
  }
```

From what I can gather is that any exe starting with `dotnet-` becomes callable in the build pipline as shown above in the `precompile` setting.

However I can't figure out why it doesn't reference the chained dependency (`SimpleGitVersion.Core`) despite it downloading and installing it. So I've just jammed the required files in the toplevel package.

If you want to merge it in, but needs some changes, let me know.
